### PR TITLE
Add `Vi` struct + event listener + update to 2018 edition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
+name = "gloo-events"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088514ec8ef284891c762c88a66b639b3a730134714692ee31829765c5bc814f"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,6 +119,7 @@ name = "visnake"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "gloo-events",
  "gloo-timers",
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,9 +24,94 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.1.29"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
+checksum = "5c329ae8753502fb44ae4fc2b622fa2a94652c41e795143765ba0927f92ab780"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c77d04ce8edd9cb903932b608268b3fffec4163dc053b3b402bf47eac1f1a8"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f25592f769825e89b92358db00d26f965761e094951ac44d3663ef25b7ac464a"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f674f3e1bcb15b37284a90cedf55afdba482ab061c407a9c0ebbd0f3109741ba"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a638959aa96152c7a4cddf50fcb1e3fede0583b27157c26e67d6f99904090dc6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a5081aa3de1f7542a794a397cde100ed903b0630152d0973479018fd85423a7"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3466821b4bc114d95b087b850a724c6f83115e929bc88f1fa98a3304a944c8a6"
+
+[[package]]
+name = "futures-task"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b0a34e53cf6cdcd0178aa573aed466b646eb3db769570841fda0c7ede375a27"
+
+[[package]]
+name = "futures-util"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22766cf25d64306bedf0384da004d05c9974ab104fcc4528f1236181c18004c5"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
 
 [[package]]
 name = "gloo-events"
@@ -74,6 +159,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5894c618ce612a3fa23881b152b608bafb8c56cfc22f434a3ba3120b40f7b587"
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcfdefadc3d57ca21cf17990a28ef4c0f7c61383a28cb7604cf4a18e6ede1420"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,6 +205,12 @@ name = "scoped-tls"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "syn"
@@ -123,7 +238,7 @@ dependencies = [
  "gloo-timers",
  "js-sys",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.3.27",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
 ]
@@ -151,19 +266,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83420b37346c311b9ed822af41ec2e82839bfe99867ec6c54e2da43b7538771c"
-dependencies = [
- "cfg-if",
- "futures",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -217,7 +319,7 @@ dependencies = [
  "js-sys",
  "scoped-tls",
  "wasm-bindgen",
- "wasm-bindgen-futures 0.4.9",
+ "wasm-bindgen-futures",
  "wasm-bindgen-test-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-bindgen = "0.2"
 gloo-timers = "0.2"
+gloo-events = "0.1"
 
 [dependencies.web-sys]
 version = "0.3"
@@ -21,6 +22,7 @@ features = [
   "Element",
   "HtmlElement",
   "HtmlCanvasElement",
+  "KeyboardEvent",
   "Node",
   "Window",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,14 +4,17 @@ authors = ["Christian Fosli <cfosli@gmail.com>"]
 categories = ["wasm"]
 license = "MIT"
 version = "0.1.0"
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
 gloo-timers = "0.2"
 gloo-events = "0.1"
+futures = "0.3"
 
 [dependencies.web-sys]
 version = "0.3"
@@ -29,6 +32,4 @@ features = [
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"
-futures = "0.1"
 js-sys = "0.3"
-wasm-bindgen-futures = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,12 @@
+extern crate gloo_events;
 extern crate gloo_timers;
 extern crate wasm_bindgen;
 extern crate web_sys;
+use gloo_events::EventListener;
 use gloo_timers::callback::Interval;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
-use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement, HtmlElement};
+use web_sys::{CanvasRenderingContext2d, Document, HtmlCanvasElement, HtmlElement, KeyboardEvent};
 
 mod snake;
 use crate::snake::*;
@@ -17,7 +19,34 @@ pub fn run() -> Result<(), JsValue> {
     let mut snake = Snake::new();
     draw_snake(&snake)?;
 
+    let document: Document = web_sys::window()
+        .unwrap()
+        .document()
+        .unwrap()
+        .dyn_into::<Document>()
+        .unwrap();
+
+    let mut direction = snake.direction;
+
+    EventListener::new(&document, "keydown", move |event| {
+        let event: &KeyboardEvent = event.dyn_ref::<KeyboardEvent>().unwrap();
+        let key: &str = &event.key();
+        let dir: Option<Direction> = match key {
+            "h" => Some(Direction::Left),
+            "j" => Some(Direction::Down),
+            "k" => Some(Direction::Up),
+            "l" => Some(Direction::Right),
+            _ => None,
+        };
+        match dir {
+            Some(dir) => direction = dir,
+            None => (),
+        };
+    })
+    .forget();
+
     Interval::new(500, move || {
+        snake.direction = direction;
         let (moved_snake, old_tail) = snake.move_along();
         draw_snake(&moved_snake).unwrap();
         clear_tail(&old_tail, moved_snake.thickness).unwrap();

--- a/src/snake.rs
+++ b/src/snake.rs
@@ -2,7 +2,7 @@
 pub struct Snake {
     pub body: Vec<Position>,
     pub thickness: f64,
-    direction: Direction,
+    pub direction: Direction,
 }
 
 impl Snake {

--- a/src/vi.rs
+++ b/src/vi.rs
@@ -1,0 +1,44 @@
+use crate::Direction;
+use futures::channel::mpsc;
+use futures::stream::Stream;
+use gloo_events::EventListener;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use wasm_bindgen::JsCast;
+use web_sys::{EventTarget, KeyboardEvent};
+
+pub struct Vi {
+    pub receiver: mpsc::UnboundedReceiver<Direction>,
+    listener: EventListener,
+}
+
+impl Vi {
+    pub fn new(target: &EventTarget) -> Self {
+        let (sender, receiver) = mpsc::unbounded();
+        let listener = EventListener::new(&target, "keydown", move |event| {
+            let event: &KeyboardEvent = event.dyn_ref::<KeyboardEvent>().unwrap();
+            let key: &str = &event.key();
+            let dir: Option<Direction> = match key {
+                "h" => Some(Direction::Left),
+                "j" => Some(Direction::Down),
+                "k" => Some(Direction::Up),
+                "l" => Some(Direction::Right),
+                _ => None,
+            };
+            match dir {
+                Some(dir) => sender.unbounded_send(dir).unwrap(),
+                None => (),
+            };
+        });
+
+        Self { receiver, listener }
+    }
+}
+
+impl Stream for Vi {
+    type Item = Direction;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        Pin::new(&mut self.receiver).poll_next(cx)
+    }
+}

--- a/tests/wasm.rs
+++ b/tests/wasm.rs
@@ -1,7 +1,3 @@
-extern crate visnake;
-extern crate wasm_bindgen;
-extern crate wasm_bindgen_test;
-extern crate web_sys;
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);


### PR DESCRIPTION
* Adds Vi struct for translating key events to directions

* Adds an event listener for keydown

BUT I can't figure out how to change the direction in one block without invalidating it
for being used in the interval closure. So the snake doesn't actually change directions yet...

Adding "Edition=2018" to cargo.toml gave a lot of advantages,
such as using `.await` and not having to put `extern crate` everywhere

