### PR TITLE
Fix "vim mode" by using `Arc<Mutex<Direction>>`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,16 +124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-events"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "088514ec8ef284891c762c88a66b639b3a730134714692ee31829765c5bc814f"
-dependencies = [
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "gloo-timers"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-events"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088514ec8ef284891c762c88a66b639b3a730134714692ee31829765c5bc814f"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/vi.rs
+++ b/src/vi.rs
@@ -9,7 +9,7 @@ use web_sys::{EventTarget, KeyboardEvent};
 
 pub struct Vi {
     pub receiver: mpsc::UnboundedReceiver<Direction>,
-    listener: EventListener,
+    pub listener: EventListener,
 }
 
 impl Vi {


### PR DESCRIPTION
By having direction be an `Arc<Mutex<Direction>>` instead of a `Direction`
we can modify its value from the vim key-listener,
and read the new value in the interval closure!

Thanks to [stackoverflow!](https://stackoverflow.com/a/61354675/10374042)